### PR TITLE
Setup brakeman

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,10 @@ jobs:
           command: bundle exec rubocop
 
       - run:
+          name: Static security analysis on the application codebase
+          command: bundle exec brakeman --quiet -f plain
+
+      - run:
           name: Audit Gemfile bundle for security issues
           command: bundle exec bundle-audit check --update --ignore CVE-2015-9284
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,7 @@ GEM
     arel (9.0.0)
     ast (2.4.1)
     awesome_print (1.8.0)
+    brakeman (4.8.2)
     builder (3.2.4)
     bundler-audit (0.7.0.1)
       bundler (>= 1.2.0, < 3)
@@ -205,6 +206,7 @@ PLATFORMS
 
 DEPENDENCIES
   awesome_print
+  brakeman
   bundler-audit
   darjeelink!
   dotenv-rails

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,26 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Mass Assignment",
+      "warning_code": 70,
+      "fingerprint": "4c710243b0d9f3f174b1b0b465dcd19aca14b1f1a9658572b13a1172855b6ed7",
+      "check_name": "MassAssignment",
+      "message": "Parameters should be whitelisted for mass assignment",
+      "file": "app/controllers/darjeelink/short_links_controller.rb",
+      "line": 83,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.permit!",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Darjeelink::ShortLinksController",
+        "method": "build_url"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "note": "The params aren't being use to create a record, we just use it to merge params that might be present on the shortened url and the source url"
+    }
+  ],
+  "updated": "2020-07-23 16:52:33 +0000",
+  "brakeman_version": "4.8.2"
+}

--- a/darjeelink.gemspec
+++ b/darjeelink.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'will_paginate'
 
   s.add_development_dependency 'awesome_print'
+  s.add_development_dependency 'brakeman'
   s.add_development_dependency 'bundler-audit'
   s.add_development_dependency 'dotenv-rails'
   s.add_development_dependency 'rspec-rails'


### PR DESCRIPTION
Keep an eye on potential security vulnerabilities

There was only one warning, and I don't think it is a vulnerability

https://brakemanscanner.org/docs/warning_types/mass_assignment/ They are worrried about it allowing attackers to control updates/creates of records.  But our usage is not on the database.  It is to allow us to merge url params.

i.e.
shortened_url https://www.example.com?param1=yes
visit 38d.gs/foo?param2=yes

You will end up at 38d.gs/foo?param1=yes&param2=no

This was a feature that the users wanted, and allows utm tracking to work properly.