### PR TITLE
enabling csrf in api call

### DIFF
--- a/app/controllers/darjeelink/api_controller.rb
+++ b/app/controllers/darjeelink/api_controller.rb
@@ -4,6 +4,7 @@ module Darjeelink
   class ApiController < Darjeelink::ApplicationController
     skip_before_action :check_ip_whitelist
     skip_before_action :authenticate
+    skip_before_action :verify_authenticity_token
 
     before_action :authenticate_token
 

--- a/app/controllers/darjeelink/application_controller.rb
+++ b/app/controllers/darjeelink/application_controller.rb
@@ -3,7 +3,6 @@
 module Darjeelink
   class ApplicationController < ActionController::Base
     protect_from_forgery with: :exception
-    protect_from_forgery unless: -> { request.format.json? }
 
     before_action :check_ip_whitelist
     before_action :authenticate

--- a/app/controllers/darjeelink/application_controller.rb
+++ b/app/controllers/darjeelink/application_controller.rb
@@ -3,6 +3,7 @@
 module Darjeelink
   class ApplicationController < ActionController::Base
     protect_from_forgery with: :exception
+    protect_from_forgery unless: -> { request.format.json? }
 
     before_action :check_ip_whitelist
     before_action :authenticate


### PR DESCRIPTION
Enable CSRF in api calls so we can use it in Flow