### PR TITLE
DEVOPS-31 - Tweak to make code release version reflect git hub release versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    darjeelink (0.14.3)
+    darjeelink (0.14.5)
       omniauth (~> 1.9, < 3.0)
       omniauth-google-oauth2
       pg

--- a/lib/darjeelink/version.rb
+++ b/lib/darjeelink/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Darjeelink
-  VERSION = '0.14.3'
+  VERSION = '0.14.5'
 end


### PR DESCRIPTION
Syncing the version number with the github releases.This is currenly at 0.14.4, so update code and Gemfile lock to be 0.14.5 so that they are consistent.

See: https://github.com/38degrees/darjeelink/releases