### PR TITLE
DEVOPS-31: Rolling back back possibly invalid changes made to check ip_whitelist method and adding rubocop ignores.

### DIFF
--- a/app/controllers/darjeelink/application_controller.rb
+++ b/app/controllers/darjeelink/application_controller.rb
@@ -13,12 +13,15 @@ module Darjeelink
     #
     # rubocop:disable Metrics/AbcSize
     # rubocop:disable Layout/LineLength
+    # Check user IP address against whitelist from ENV
     def check_ip_whitelist
       return unless Rails.env.production?
       return unless Rails.application.config.permitted_ips
-      return if Rails.application.config.permitted_ips.split(',').include? request.ip
-
-      ip_to_verify = Rails.application.client_ip_header ? request.headers[Rails.application.client_ip_header] : request.ip
+      ip_to_verify = if Rails.application.config.respond_to?(:client_ip_header) && Rails.application.config.client_ip_header.present?
+          request.headers[Rails.application.config.client_ip_header]
+        else
+          request.ip
+        end
 
       return if Rails.application.config.permitted_ips.split(',').include? ip_to_verify
 

--- a/app/controllers/darjeelink/application_controller.rb
+++ b/app/controllers/darjeelink/application_controller.rb
@@ -17,11 +17,12 @@ module Darjeelink
     def check_ip_whitelist
       return unless Rails.env.production?
       return unless Rails.application.config.permitted_ips
+
       ip_to_verify = if Rails.application.config.respond_to?(:client_ip_header) && Rails.application.config.client_ip_header.present?
-          request.headers[Rails.application.config.client_ip_header]
-        else
-          request.ip
-        end
+                       request.headers[Rails.application.config.client_ip_header]
+                     else
+                       request.ip
+                     end
 
       return if Rails.application.config.permitted_ips.split(',').include? ip_to_verify
 

--- a/app/controllers/darjeelink/application_controller.rb
+++ b/app/controllers/darjeelink/application_controller.rb
@@ -9,25 +9,23 @@ module Darjeelink
 
     private
 
-    def determine_ip_to_verify
-      if Rails.application.client_ip_header
-        request.headers[Rails.application.client_ip_header]
-      else
-        request.ip
-      end
-    end
-
-    # Check user IP address against whitelist from ENV
+    # Disabling these rubocop rules. This is a simple function and tested in production sinve version 0.14.4.
+    #
+    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Layout/LineLength
     def check_ip_whitelist
       return unless Rails.env.production?
       return unless Rails.application.config.permitted_ips
+      return if Rails.application.config.permitted_ips.split(',').include? request.ip
 
-      ip_to_verify = determine_ip_to_verify
+      ip_to_verify = Rails.application.client_ip_header ? request.headers[Rails.application.client_ip_header] : request.ip
 
       return if Rails.application.config.permitted_ips.split(',').include? ip_to_verify
 
       render plain: 'Access Denied', status: :forbidden
     end
+    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Layout/LineLength
 
     # Authenticate against Google OAuth
     def authenticate


### PR DESCRIPTION
**Overview**

What it says in the comments. Tweaked an existing method that had some rubocop errors to resolve them, and this might have broken the function. So, rolling back to the original, and disable the rubocop checks. This will hopefully fix the issue and confirm this as the cause (not some deeper issue with new Rails libraries, etc).

NB: This is the merge with the original function: https://github.com/38degrees/darjeelink/pull/75 - would appreciate a check I did not fat finger it.

NB2: Dont think I worked on this much before, so forgot to change to squash and commit. Sox.
