### PR TITLE
DEVOPS-31: Moving helper docs from Darjeelink repo to Portkey.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,28 +120,7 @@ Change the database url to be different to the development one i.e. `postgres://
 ## Releasing
 Darjeelink follows [Semantic Versioning](https://semver.org)
 
-### Pre-releasing - Staging tests
-There are several ways to test the gem before releasing it.
-
-One way, is to check the new development branch into Github, and then use `portkey-app` to test it in a staging environment.
-
-- Create a new branch in the `darjeelink` repo with a sensible name related to your intended release: e.g. `darjeelink-v0.14.6-upgrade`.
-  - Perform the required upgrades, security patching, etc for the new release.
-  - Bump the version number as required (see below).
-- Create a new branch in the `portkey-app` repo with a sensible name related to your intdended release: e.g. `darjeelink-v0.14.6-upgrade`.
-- In the `Gemfile` of the portkey-app repo, change the `darjeelink` gem to point to the branch you just created in the darjeelink repo.
-  ```gemfile
-  # Actual URL Shortener
-  # gem 'darjeelink' <-- Temporarilly change this. Remeber to change it back, and run bundle install to update the Gemfile.lock when done!
-  gem 'darjeelink', git: 'https://github.com/38degrees/darjeelink.git',
-                    branch: 'darjeelink-v0.14.6-upgrade'
-  ```
-- Update the `Gemfile.lock` in the `portkey-app` repo by running `bundle install` and commit then push the changes.
-- Deploy your branch of the portkey-app to the staging environment and test the changes.
-
-NB: When you have followed the production release steps below and created a GitHub release, you can then update the `Gemfile` in the `portkey-app` repo to point to the new release tag. 
-
-### Releasing - Production
+NB: Before releasing, ensure that the gem is working as expected by running the tests. If possible perform some manual testing via a webserver. 
 
 Once all necessary changes have made it in to master and you are ready to do a release you need to do these steps.
 


### PR DESCRIPTION
Overview

REmoved some docs that help explain how to test the Darjeelink gem when we change it.

NB: These have actually been moved from the Portkey repo - as this is used to host the GEM and manually test it.